### PR TITLE
feat: add SQLite order projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Example response:
 
 Replaying the same request returns the same `orderId` without duplicating events.
 
+## Query the SQLite projection
+The background projector subscribes to the event store, upserts the `order_views` table in `data/read-model.sqlite`, and resumes from its checkpoint after restarts. Once the projector processes the `OrderCreated` event you can fetch the read model:
+
+```bash
+ORDER_ID="<orderId-from-create-response>"
+curl -s "http://localhost:8080/orders/${ORDER_ID}" | jq
+```
+
+The response reflects the projected state (`status`, `paymentRequested`, etc.). Check `/metrics` for the `projector_event_lag_seconds{projector="order-sqlite-projector"}` gauge to confirm the worker is keeping up.
+
+> 🧹 **Resets**: if you wipe `data/events.jsonl` to start fresh, also remove `data/read-model.sqlite*` so the projector rebuilds the read model from the new stream.
+
 ## Exercise the Event Store
 Run the manual script that appends an event and then replays the JSONL file:
 

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,3 @@
 # Event Store generated data
 *.jsonl
+read-model.sqlite*

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@nestjs/common": "^10.4.0",
         "@nestjs/core": "^10.4.0",
         "@nestjs/platform-express": "^10.4.0",
+        "better-sqlite3": "^12.2.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "prom-client": "^15.1.2",
@@ -18,6 +19,7 @@
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/express": "^5.0.3",
         "@types/node": "^22.5.4",
         "ts-node-dev": "^2.0.0",
@@ -275,6 +277,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -496,6 +508,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz",
+      "integrity": "sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -509,11 +555,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -561,6 +627,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -658,6 +748,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
@@ -787,6 +883,30 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -804,6 +924,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -855,6 +984,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -898,6 +1036,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -982,6 +1129,12 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1030,6 +1183,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -1098,6 +1257,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1243,6 +1408,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -1407,6 +1578,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1441,6 +1624,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1465,6 +1654,12 @@
         "node": ">= 10.16.0"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1472,6 +1667,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-fetch": {
@@ -1541,7 +1748,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -1592,6 +1798,32 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prom-client": {
       "version": "15.1.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
@@ -1616,6 +1848,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -1655,6 +1897,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/readable-stream": {
@@ -1759,6 +2016,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -1892,6 +2161,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1953,7 +2267,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1998,6 +2311,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tdigest": {
@@ -2176,6 +2517,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -2309,7 +2662,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@nestjs/common": "^10.4.0",
     "@nestjs/core": "^10.4.0",
     "@nestjs/platform-express": "^10.4.0",
+    "better-sqlite3": "^12.2.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "prom-client": "^15.1.2",
@@ -19,6 +20,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.3",
     "@types/node": "^22.5.4",
     "ts-node-dev": "^2.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,19 @@ import { MetricsController } from './infrastructure/metrics/metrics.controller';
 import { OrdersController } from './infrastructure/http/orders.controller';
 import { FileEventStore } from './infrastructure/eventstore/file-event-store';
 import { CreateOrderHandler } from './application/handlers/create-order.handler';
+import { ProjectionDatabase, SqliteOrderProjection } from './infrastructure/projections/sqlite-projection';
+import { CheckpointStore } from './infrastructure/projections/checkpoint-store';
+import { OrderProjector } from './infrastructure/projections/projector';
 
 @Module({
   controllers: [HealthController, MetricsController, OrdersController],
-  providers: [FileEventStore, CreateOrderHandler],
+  providers: [
+    FileEventStore,
+    CreateOrderHandler,
+    ProjectionDatabase,
+    SqliteOrderProjection,
+    CheckpointStore,
+    OrderProjector
+  ]
 })
 export class AppModule {}

--- a/src/infrastructure/http/orders.controller.ts
+++ b/src/infrastructure/http/orders.controller.ts
@@ -1,11 +1,24 @@
-import { Body, Controller, HttpStatus, Post, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  Post,
+  Res
+} from '@nestjs/common';
 import { CreateOrderCommand } from '../../domain/commands/create-order';
 import { CreateOrderHandler } from '../../application/handlers/create-order.handler';
 import type { Response } from 'express';
+import { SqliteOrderProjection } from '../projections/sqlite-projection';
 
 @Controller('orders')
 export class OrdersController {
-  constructor(private readonly createOrderHandler: CreateOrderHandler) {}
+  constructor(
+    private readonly createOrderHandler: CreateOrderHandler,
+    private readonly projection: SqliteOrderProjection
+  ) {}
 
   @Post()
   async create(
@@ -15,5 +28,27 @@ export class OrdersController {
     const result = await this.createOrderHandler.execute(command);
     res.status(result.created ? HttpStatus.CREATED : HttpStatus.OK);
     return { orderId: result.orderId };
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') orderId: string) {
+    const view = this.projection.getOrderById(orderId);
+    if (!view) {
+      throw new NotFoundException('order not found');
+    }
+
+    return {
+      orderId: view.orderId,
+      clientRequestId: view.clientRequestId,
+      customerId: view.customerId,
+      items: view.items,
+      totalAmount: view.totalAmount,
+      currency: view.currency,
+      status: view.status,
+      paymentRequested: view.paymentRequested,
+      version: view.version,
+      createdAt: view.createdAt,
+      updatedAt: view.updatedAt
+    };
   }
 }

--- a/src/infrastructure/projections/checkpoint-store.ts
+++ b/src/infrastructure/projections/checkpoint-store.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import type { Statement } from 'better-sqlite3';
+import { ProjectionDatabase } from './sqlite-projection';
+
+type CheckpointRow = {
+  last_offset: number;
+};
+
+@Injectable()
+export class CheckpointStore {
+  private readonly getStmt: Statement;
+  private readonly upsertStmt: Statement;
+
+  constructor(private readonly database: ProjectionDatabase) {
+    const db = this.database.connection;
+    this.getStmt = db.prepare(`
+      SELECT last_offset
+      FROM projection_checkpoints
+      WHERE projector_name = @projector_name
+    `);
+
+    this.upsertStmt = db.prepare(`
+      INSERT INTO projection_checkpoints (
+        projector_name,
+        last_offset,
+        updated_at
+      ) VALUES (
+        @projector_name,
+        @last_offset,
+        @updated_at
+      )
+      ON CONFLICT(projector_name) DO UPDATE SET
+        last_offset = excluded.last_offset,
+        updated_at = excluded.updated_at;
+    `);
+  }
+
+  async getLastOffset(projectorName: string): Promise<number | null> {
+    const row = this.getStmt.get({ projector_name: projectorName }) as
+      | CheckpointRow
+      | undefined;
+    if (!row) {
+      return null;
+    }
+
+    return row.last_offset;
+  }
+
+  async saveLastOffset(projectorName: string, offset: number): Promise<void> {
+    this.upsertStmt.run({
+      projector_name: projectorName,
+      last_offset: offset,
+      updated_at: new Date().toISOString()
+    });
+  }
+}

--- a/src/infrastructure/projections/projector.ts
+++ b/src/infrastructure/projections/projector.ts
@@ -1,0 +1,143 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Gauge, Registry } from 'prom-client';
+import { FileEventStore } from '../eventstore/file-event-store';
+import { SqliteOrderProjection } from './sqlite-projection';
+import { CheckpointStore } from './checkpoint-store';
+import type { OrderEvent } from '../../domain/aggregates/order';
+import type { StoredEvent } from '../../domain/events';
+
+const PROJECTOR_NAME = 'order-sqlite-projector';
+const DEFAULT_POLL_INTERVAL_MS = 500;
+
+@Injectable()
+export class OrderProjector implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(OrderProjector.name);
+  private readonly pollIntervalMs: number;
+  private running = false;
+  private loopPromise: Promise<void> | null = null;
+  private eventLagGauge: Gauge<string> | null = null;
+
+  constructor(
+    private readonly eventStore: FileEventStore,
+    private readonly projection: SqliteOrderProjection,
+    private readonly checkpointStore: CheckpointStore
+  ) {
+    this.pollIntervalMs = Number(process.env.PROJECTOR_POLL_INTERVAL_MS || DEFAULT_POLL_INTERVAL_MS);
+  }
+
+  async onModuleInit(): Promise<void> {
+    this.running = true;
+    this.loopPromise = this.runLoop();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.running = false;
+    if (this.loopPromise) {
+      await this.loopPromise;
+    }
+  }
+
+  private async runLoop(): Promise<void> {
+    while (this.running) {
+      try {
+        const lastOffset = await this.checkpointStore.getLastOffset(PROJECTOR_NAME);
+        const fromOffset = lastOffset === null ? 0 : lastOffset + 1;
+        let processed = false;
+
+        for await (const event of this.eventStore.stream(fromOffset)) {
+          await this.handleEvent(event);
+          await this.checkpointStore.saveLastOffset(PROJECTOR_NAME, event.offset);
+          this.updateLagMetric(event);
+          processed = true;
+        }
+
+        if (!processed) {
+          await this.delay(this.pollIntervalMs);
+        }
+      } catch (error: unknown) {
+        const err = error as Error;
+        this.logger.error(`Projector loop failed: ${err.message}`, err.stack);
+        await this.delay(this.pollIntervalMs);
+      }
+    }
+  }
+
+  private async handleEvent(event: StoredEvent): Promise<void> {
+    if (!this.isOrderEvent(event)) {
+      return;
+    }
+
+    try {
+      this.projection.project(event);
+    } catch (error: unknown) {
+      const err = error as Error;
+      this.logger.error(
+        `Failed to project event ${event.type}#${event.metadata.eventId}: ${err.message}`,
+        err.stack
+      );
+      throw error;
+    }
+  }
+
+  private updateLagMetric(event: StoredEvent): void {
+    const gauge = this.ensureEventLagGauge();
+    if (!gauge) {
+      return;
+    }
+
+    const eventTimestamp = Date.parse(event.metadata.ts);
+    if (Number.isNaN(eventTimestamp)) {
+      return;
+    }
+
+    const now = Date.now();
+    const lagSeconds = Math.max(0, (now - eventTimestamp) / 1000);
+    gauge.labels({ projector: PROJECTOR_NAME }).set(lagSeconds);
+  }
+
+  private ensureEventLagGauge(): Gauge<string> | null {
+    if (this.eventLagGauge) {
+      return this.eventLagGauge;
+    }
+
+    const registry = this.tryGetMetricsRegistry();
+    if (!registry) {
+      return null;
+    }
+
+    const gauge = new Gauge({
+      name: 'projector_event_lag_seconds',
+      help: 'Lag in seconds between the latest processed event and now',
+      labelNames: ['projector'] as const
+    });
+
+    try {
+      registry.registerMetric(gauge);
+      this.eventLagGauge = gauge;
+    } catch (error: unknown) {
+      // Metric might already be registered; retrieve it instead of failing the worker.
+      const existing = registry.getSingleMetric('projector_event_lag_seconds');
+      if (existing && existing instanceof Gauge) {
+        this.eventLagGauge = existing as Gauge<string>;
+      } else {
+        this.logger.warn('Unable to register projector_event_lag_seconds metric');
+        this.eventLagGauge = null;
+      }
+    }
+
+    return this.eventLagGauge;
+  }
+
+  private tryGetMetricsRegistry(): Registry | null {
+    const registry = (global as any).__metricsRegistry as Registry | undefined;
+    return registry ?? null;
+  }
+
+  private isOrderEvent(event: StoredEvent): event is StoredEvent & OrderEvent {
+    return event.type === 'order.created' || event.type === 'payment.requested';
+  }
+
+  private async delay(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/src/infrastructure/projections/sqlite-projection.ts
+++ b/src/infrastructure/projections/sqlite-projection.ts
@@ -1,0 +1,228 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import type { Database as BetterSqlite3Database, Statement } from 'better-sqlite3';
+import DatabaseConstructor = require('better-sqlite3');
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+import type {
+  OrderCreatedEvent,
+  OrderEvent,
+  PaymentRequestedEvent,
+  OrderItem
+} from '../../domain/aggregates/order';
+
+export interface OrderView {
+  orderId: string;
+  clientRequestId: string;
+  customerId: string;
+  items: OrderItem[];
+  totalAmount: number;
+  currency: string;
+  status: string;
+  paymentRequested: boolean;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface OrderViewRow {
+  order_id: string;
+  client_request_id: string;
+  customer_id: string;
+  items_json: string;
+  total_amount: number;
+  currency: string;
+  status: string;
+  payment_requested: number;
+  version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+@Injectable()
+export class ProjectionDatabase implements OnModuleDestroy {
+  private readonly db: BetterSqlite3Database;
+
+  constructor() {
+    const dataDir = join(process.cwd(), 'data');
+    mkdirSync(dataDir, { recursive: true });
+    const dbPath = join(dataDir, 'read-model.sqlite');
+
+    this.db = new DatabaseConstructor(dbPath);
+    this.initialize();
+  }
+
+  get connection(): BetterSqlite3Database {
+    return this.db;
+  }
+
+  private initialize(): void {
+    this.db.pragma('journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS order_views (
+        order_id TEXT PRIMARY KEY,
+        client_request_id TEXT NOT NULL,
+        customer_id TEXT NOT NULL,
+        items_json TEXT NOT NULL,
+        total_amount REAL NOT NULL,
+        currency TEXT NOT NULL,
+        status TEXT NOT NULL,
+        payment_requested INTEGER NOT NULL,
+        version INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS projection_checkpoints (
+        projector_name TEXT PRIMARY KEY,
+        last_offset INTEGER NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+  }
+
+  onModuleDestroy(): void {
+    this.db.close();
+  }
+}
+
+@Injectable()
+export class SqliteOrderProjection {
+  private readonly insertOrUpdateOrderStmt: Statement;
+  private readonly markPaymentRequestedStmt: Statement;
+  private readonly getOrderByIdStmt: Statement;
+
+  constructor(private readonly database: ProjectionDatabase) {
+    const db = this.database.connection;
+
+    this.insertOrUpdateOrderStmt = db.prepare(`
+      INSERT INTO order_views (
+        order_id,
+        client_request_id,
+        customer_id,
+        items_json,
+        total_amount,
+        currency,
+        status,
+        payment_requested,
+        version,
+        created_at,
+        updated_at
+      ) VALUES (
+        @order_id,
+        @client_request_id,
+        @customer_id,
+        @items_json,
+        @total_amount,
+        @currency,
+        @status,
+        @payment_requested,
+        @version,
+        @created_at,
+        @updated_at
+      )
+      ON CONFLICT(order_id) DO UPDATE SET
+        client_request_id = excluded.client_request_id,
+        customer_id = excluded.customer_id,
+        items_json = excluded.items_json,
+        total_amount = excluded.total_amount,
+        currency = excluded.currency,
+        status = excluded.status,
+        payment_requested = excluded.payment_requested,
+        version = excluded.version,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at;
+    `);
+
+    this.markPaymentRequestedStmt = db.prepare(`
+      UPDATE order_views
+      SET
+        status = @status,
+        payment_requested = @payment_requested,
+        version = @version,
+        updated_at = @updated_at
+      WHERE order_id = @order_id;
+    `);
+
+    this.getOrderByIdStmt = db.prepare(`
+      SELECT
+        order_id,
+        client_request_id,
+        customer_id,
+        items_json,
+        total_amount,
+        currency,
+        status,
+        payment_requested,
+        version,
+        created_at,
+        updated_at
+      FROM order_views
+      WHERE order_id = @order_id
+    `);
+  }
+
+  project(event: OrderEvent): void {
+    switch (event.type) {
+      case 'order.created':
+        this.applyOrderCreated(event);
+        break;
+      case 'payment.requested':
+        this.applyPaymentRequested(event);
+        break;
+      default:
+        // ignore events not related to the order read model
+        break;
+    }
+  }
+
+  getOrderById(orderId: string): OrderView | null {
+    const row = this.getOrderByIdStmt.get({ order_id: orderId }) as
+      | OrderViewRow
+      | undefined;
+    if (!row) {
+      return null;
+    }
+
+    return {
+      orderId: row.order_id,
+      clientRequestId: row.client_request_id,
+      customerId: row.customer_id,
+      items: JSON.parse(row.items_json) as OrderItem[],
+      totalAmount: row.total_amount,
+      currency: row.currency,
+      status: row.status,
+      paymentRequested: row.payment_requested === 1,
+      version: row.version,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    };
+  }
+
+  private applyOrderCreated(event: OrderCreatedEvent): void {
+    const payload = event.payload;
+
+    this.insertOrUpdateOrderStmt.run({
+      order_id: payload.orderId,
+      client_request_id: payload.clientRequestId,
+      customer_id: payload.customerId,
+      items_json: JSON.stringify(payload.items),
+      total_amount: payload.totalAmount,
+      currency: payload.currency,
+      status: 'created',
+      payment_requested: 0,
+      version: event.metadata.version,
+      created_at: event.metadata.ts,
+      updated_at: event.metadata.ts
+    });
+  }
+
+  private applyPaymentRequested(event: PaymentRequestedEvent): void {
+    this.markPaymentRequestedStmt.run({
+      order_id: event.payload.orderId,
+      status: 'payment-requested',
+      payment_requested: 1,
+      version: event.metadata.version,
+      updated_at: event.metadata.ts
+    });
+  }
+}


### PR DESCRIPTION
# Summary

- Add a SQLite-backed order projection and background projector to keep the read model synchronized with the event store.
- Expose GET /orders/:id to return the projected order view and document how to query/reset the projection.

# Context & Links
N/A

# Changes

- Introduce ProjectionDatabase, SqliteOrderProjection, CheckpointStore, and OrderProjector services.
- Wire the projector into the Nest module and surface projected data through the orders controller.
- Add Prometheus gauge projector_event_lag_seconds and README instructions for querying the read model.
- Add better-sqlite3 runtime dependency and typings; ignore generated SQLite files.

# Screenshots / Demos (if applicable)
N/A

# How to Test

1. npm install
2. npm run start:dev
3. `curl -s http://localhost:8080/orders -H 'content-type: application/json' -d '{...}' | jq` to create an order.
4. `curl -s "http://localhost:8080/orders/${ORDER_ID}" | jq` using the returned `orderId` to verify projected fields (`status`, `paymentRequested`, etc.).
5. Optionally poll /metrics and confirm `projector_event_lag_seconds{projector="order-sqlite-projector"} `is near zero.

# Risk & Rollback Plan

- Risk: projector loop could exit on unexpected errors; monitor logs and metrics.
- Risk: better-sqlite3 native build requires compatible Node runtime.
- Rollback: deploy previous version (without projector) and remove data/read-model.sqlite* artifacts.

# Checklist
- [ ] Unit/Integration tests added or updated
- [x] Docs updated (README/CHANGELOG)
- [x] No breaking changes (or clearly documented)
- [ ] Labels set (feature/area)
- [ ] Security/UX review (if applicable)

# Release Notes (optional)
Added a SQLite read model projector and /orders/:id endpoint to query projected order state.