### PR TITLE
fix(outbox): disable default fail-once flag in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,5 @@ OUTBOX_DISPATCHER_MAX_BACKOFF_MS=30000
 # Projector polling interval
 PROJECTOR_POLL_INTERVAL_MS=500
 
-OUTBOX_DISPATCHER_FAIL_ONCE=true
+# Only true to try outbox error handler
+OUTBOX_DISPATCHER_FAIL_ONCE=false


### PR DESCRIPTION
# Summary
Remove the accidental OUTBOX_DISPATCHER_FAIL_ONCE=true default from .env.example so new environments don’t simulate failures by default.

# Root Cause
The initial RabbitMQ integration committed .env.example with the failure injection flag enabled, causing the dispatcher to always fail on the first send for anyone using the example file verbatim.

# Repro Steps (Before)

1. Copy .env.example to .env.
2. Start the Nest app.
3. Create an order.
4. Observe logs showing dispatch failed (attempt 1) even without opting in to failure simulation.

# Fix Details (After)

- Reset OUTBOX_DISPATCHER_FAIL_ONCE in .env.example to false.
- New environments no longer inject failures unless explicitly enabled. No code changes required; only config corrected.

# Affected Scope
Developers bootstrapping the service via .env.example; runtime behavior now matches expected defaults.

# How to Test / Verify

1. Copy the updated .env.example to .env.
2. Start the service and create an order.
3. Confirm the dispatcher publishes without logging a simulated failure.

# Risk & Rollback Plan

- Risks: None—only a default config toggle.
- Rollback: Revert the .env.example change if needed. No flags, no canary required.

# Checklist
- [ ] Regression/Unit tests added
- [x] Added/updated docs (if behavior changed)
- [ ] Linked issue(s) closed (e.g., Fixes #123)
- [ ] Labels set (bug, severity, area)
- [ ] Backport required? If yes, list target branches

# Post-Deployment Checks (optional)
<!-- Note metrics/alerts to watch or user reports to monitor after deploy. -->
